### PR TITLE
Génération automatique du XML résumé (sur 1 cas)

### DIFF
--- a/livebooks/3_reseau/reseau_rochefort.livemd
+++ b/livebooks/3_reseau/reseau_rochefort.livemd
@@ -205,18 +205,8 @@ Rochefort.list_netex_content(:markdown)
 
 Dans l'archive, nous allons à présent descendre dans le fichier "commun".
 
-```xml
-<PublicationDelivery ...>
-  ...
-    <members>
-      <Network/> (x1)
-      <Line (x14) />
-      <Operator (x1) />
-      <Authority (x1) />
-      <SiteConnection (x81) />
-    </members>
-  ...
-</PublicationDelivery>
+```elixir
+Rochefort.xml_summary(~r/commun/)
 ```
 
 Les notions de `Network` et de `Line` sont définies dans les sections suivantes.


### PR DESCRIPTION
![CleanShot 2025-04-08 at 08 37 44@2x](https://github.com/user-attachments/assets/fcd07b61-a6ed-409c-99f8-fd1d43e8c49f)

Ça permet de générer un résumé automatique du XML "commun" pour le moment.

Je généraliserai ça un peu plus tard pour les autres cas.

Poke @adurand-cs si tu peux tester en local sur ton PC avant de valider, histoire d'être sûr que ça marche bien chez toi, ça serait top. Merci !